### PR TITLE
feature: dataset loader

### DIFF
--- a/src/preprocessing/__init__.py
+++ b/src/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+# preprocessing/__init__.py

--- a/src/preprocessing/tf_dataset_loader.py
+++ b/src/preprocessing/tf_dataset_loader.py
@@ -1,0 +1,64 @@
+__all__ = ['load_dataset']
+
+# import libraries
+import os
+import wfdb
+import numpy as np
+
+# Constants
+SAMPLE_LIMIT = 2800  # Limit the number of samples to load from each record
+DAT_EXTENSION = '.dat'  # Extension for WFDB data files
+
+def _parse_header_comments(header):
+    """ Parse the comments from the WFDB header and return them as a dictionary. """
+    comments_dict = {}
+    if header.comments:
+        for comment in header.comments:
+            comment = comment.strip()
+            if ':' in comment:
+                key, value = comment.split(':', 1)
+                comments_dict[key.strip()] = value.strip()
+                # Try to convert value to int, float, or bool if possible
+                if value.strip().lower() in ['true', 'false']:
+                    comments_dict[key.strip()] = value.strip().lower() == 'true'
+                else:
+                    try:
+                        num = int(value.strip())
+                        comments_dict[key.strip()] = num
+                    except ValueError:
+                        try:
+                            num = float(value.strip())
+                            comments_dict[key.strip()] = num
+                        except ValueError:
+                            pass
+            else:
+                comments_dict[comment] = None
+    return comments_dict
+
+def _load_wfdb_record(record_path):
+    """ Load a WFDB record and return the signal data, header, and labels."""
+    try:
+        record = wfdb.rdrecord(record_path)
+        header = wfdb.rdheader(record_path)
+        labels = _parse_header_comments(header)
+        return record.p_signal[:SAMPLE_LIMIT, :], header, labels
+    except Exception as e:
+        print(f"Error loading record {record_path}: {e}")
+        return None, None, None
+
+def load_dataset(dataset_path):
+    """ Load all WFDB records from a dataset directory and return the data and labels. """
+    all_data = []
+    all_labels = []
+    for filename in os.listdir(dataset_path):
+        if filename.endswith(DAT_EXTENSION):
+            record_path = os.path.join(dataset_path, filename[:-4])  # Remove .dat extension
+            data, _, labels = _load_wfdb_record(record_path)
+            if data is not None:
+                all_data.append(data)
+                all_labels.append(labels)
+    
+    # Stack the data
+    X_all = np.stack(all_data, axis=0)  # Shape: (n_files, n_samples, n_channels)
+    y_all = np.array(all_labels)        # Shape: (n_files,)
+    return X_all, y_all


### PR DESCRIPTION

This pull request introduces a new module for loading and preprocessing datasets in the `src/preprocessing` package. The changes include adding an `__init__.py` file to make the package importable and implementing a `tf_dataset_loader.py` file with functionality for loading and parsing WFDB records.

**New module for dataset preprocessing:**

* [`src/preprocessing/__init__.py`](diffhunk://#diff-e0c3b8a6444c273ce4be83d85902961b98a860117b52191c8c324b891de6934bR1): Added an `__init__.py` file to mark the `preprocessing` directory as a Python package.

* `src/preprocessing/tf_dataset_loader.py`: Implemented functions for loading WFDB records, parsing header comments, and assembling datasets. Key features include:
  - [`_parse_header_comments`](diffhunk://#diff-ee36bd48002b3861785e685736e7d97ae5e4f7ab16ee7b88b1d28bc1603e4664R1-R64): Parses WFDB header comments into a dictionary, with automatic type conversion for integers, floats, and booleans.
  - [`_load_wfdb_record`](diffhunk://#diff-ee36bd48002b3861785e685736e7d97ae5e4f7ab16ee7b88b1d28bc1603e4664R1-R64): Loads signal data, headers, and labels from a single WFDB record, with error handling.
  - [`load_dataset`](diffhunk://#diff-ee36bd48002b3861785e685736e7d97ae5e4f7ab16ee7b88b1d28bc1603e4664R1-R64): Loads all WFDB records from a specified directory, stacks the data into a NumPy array, and returns the signals and labels.